### PR TITLE
make duplicate page names each have a unique filename

### DIFF
--- a/lib/moodle2cc/cc/cc_helper.rb
+++ b/lib/moodle2cc/cc/cc_helper.rb
@@ -95,6 +95,7 @@ module CCHelper
   end
 
   def file_slug(name)
+    name = @section_number.nil? ? name : "#@section_number-#{name}"
     CCHelper.file_slug(name)
   end
 

--- a/lib/moodle2cc/cc/resource.rb
+++ b/lib/moodle2cc/cc/resource.rb
@@ -11,6 +11,7 @@ module Moodle2CC::CC
       @id = mod.id
       @title = mod.name
       @indent = mod.section_mod.nil? ? 0 : mod.section_mod.indent
+      @section_number = mod.section_mod.nil? ? 0 : mod.section_mod.section.number
       @identifier = create_resource_key(mod)
     end
 


### PR DESCRIPTION
Fix for when moodle pages in different sections have the same name they don't all get imported.