### PR TITLE
capture info messages output during rspec run

### DIFF
--- a/lib/moodle2cc.rb
+++ b/lib/moodle2cc.rb
@@ -13,6 +13,7 @@ require 'securerandom'
 require 'moodle2cc/error'
 require 'moodle2cc/logger'
 require 'moodle2cc/migrator'
+require 'moodle2cc/output_logger'
 
 require 'moodle2cc/moodle2'
 

--- a/lib/moodle2cc/moodle2/parsers/question_category_parser.rb
+++ b/lib/moodle2cc/moodle2/parsers/question_category_parser.rb
@@ -39,7 +39,8 @@ module Moodle2CC::Moodle2
       begin
         Parsers::QuestionParsers::QuestionParser.parse(node)
       rescue Exception => e
-        puts e.message
+        Moodle2CC::OutputLogger.logger.info e.message
+        nil
       end
     end
 

--- a/lib/moodle2cc/moodle2/parsers/question_parsers/question_parser.rb
+++ b/lib/moodle2cc/moodle2/parsers/question_parsers/question_parser.rb
@@ -44,7 +44,8 @@ module Moodle2CC::Moodle2
 
         question
       rescue Exception => e
-        puts e.message
+        Moodle2CC::OutputLogger.logger.info e.message
+        nil
       end
     end
 

--- a/lib/moodle2cc/moodle2converter/converter_helper.rb
+++ b/lib/moodle2cc/moodle2converter/converter_helper.rb
@@ -55,7 +55,7 @@ module Moodle2CC
       # use when we want to retrieve an existing id, not generate a new one
       id = Moodle2Converter::Migrator.activity_id_map[activity.hash]
       unless id
-        puts "could not find matching id for #{activity.inspect}"
+        Moodle2CC::OutputLogger.logger.info "could not find matching id for #{activity.inspect}"
         id = generate_unique_identifier_for_activity(activity)
       end
       id

--- a/lib/moodle2cc/moodle2converter/html_converter.rb
+++ b/lib/moodle2cc/moodle2converter/html_converter.rb
@@ -60,7 +60,7 @@ module Moodle2CC::Moodle2Converter
         link
       end
     rescue => e
-      puts "invalid url #{link} - #{e.message}"
+      Moodle2CC::OutputLogger.logger.info "invalid url #{link} - #{e.message}"
       link
     end
 
@@ -75,7 +75,8 @@ module Moodle2CC::Moodle2Converter
         "#{WEB_CONTENT_TOKEN}#{cc_file.file_path}"
       end
     rescue => e
-      puts "invalid url #{moodle_path} - #{e.message}"
+      Moodle2CC::OutputLogger.logger.info "invalid url #{moodle_path} - #{e.message}"
+      nil
     end
 
     def lookup_cc_link(activity, id, anchor)
@@ -93,7 +94,10 @@ module Moodle2CC::Moodle2Converter
             "#{OBJECT_TOKEN}/discussion_topics/#{get_unique_identifier_for_activity(forum)}#{anchor}"
           end
         else
-          puts "unknown activity to replace link for. activity:#{activity} id:#{id}"
+          Moodle2CC::OutputLogger.logger.info(
+            "unknown activity to replace link for. activity:#{activity} id:#{id}"
+          )
+          nil
       end
     end
 

--- a/lib/moodle2cc/moodle2converter/section_converter.rb
+++ b/lib/moodle2cc/moodle2converter/section_converter.rb
@@ -42,7 +42,8 @@ module Moodle2CC
       begin
         activity_converter_for(moodle_activity).convert_to_module_items(moodle_activity)
       rescue Exception => e
-        puts e.message
+        Moodle2CC::OutputLogger.logger.info e.message
+        nil
       end
     end
 

--- a/lib/moodle2cc/output_logger.rb
+++ b/lib/moodle2cc/output_logger.rb
@@ -1,0 +1,18 @@
+module Moodle2CC
+  # Note: the public interface for Moodle2CC::Logger is really #add_warning,
+  # which tries that method on the logger and then falls back to a more
+  # standard #warm method.  But it really doesn't expect the logger to
+  # implement the standard logger interface. Eventually it should probably be
+  # renamed to something else, and this class should be renamed to just Logger
+  # (once usage of the existing logger is moved over).  OR potentially they
+  # could be combined so that "warn" level has special functionality.
+  class OutputLogger
+    def self.logger
+      Thread.current[:__moodle2cc_output_logger__] ||= ::Logger.new(STDOUT)
+    end
+
+    def self.logger=(logger)
+      Thread.current[:__moodle2cc_output_logger__] = logger
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,19 @@ require 'moodle2cc'
 Dir["./spec/support/**/*.rb"].sort.each {|f| require f}
 
 RSpec.configure do |c|
+  c.before :suite do
+    # info log activity is logged but not printed by default, but can be
+    # triggered to print by toggling the print_finalize flag
+    Moodle2CC::OutputLogger.logger = SpecLogger.new
+    Moodle2CC::OutputLogger.logger.print_finalize = false
+  end
+
   c.after :each do
     Moodle2CC::Moodle2Converter::Migrator.clear_unique_id_set!
+  end
+
+  c.after :suite do
+    Moodle2CC::OutputLogger.logger.finalize
   end
 end
 

--- a/spec/support/spec_logger.rb
+++ b/spec/support/spec_logger.rb
@@ -1,0 +1,40 @@
+class SpecLogger
+  LOG_TYPES = %w(debug info warn error fatal)
+  attr_accessor :messages
+  attr_accessor :print_finalize
+
+  def initialize
+    @messages = {}
+    @print_finalize = false
+  end
+
+  # def info(msg)
+  #   messages['info'] ||= []
+  #   messages['info'] << msg
+  # end
+
+  LOG_TYPES.each do |name|
+    class_eval <<-RUBY, __FILE__, __LINE__ + 1
+      def #{name}(msg)
+        messages['#{name}'] ||= []
+        messages['#{name}'] << [msg, caller]
+      end
+    RUBY
+  end
+
+  def finalize
+    return unless print_finalize
+    return if messages.empty?
+
+    puts "\n"
+    LOG_TYPES.each do |name|
+      if msgs = messages[name]
+        puts "\n*** Messages for type #{name} ***"
+        msgs.each do |msg, loc|
+          puts "\n#{msg}"
+          loc.reject{|l| l =~ /rspec/ }.each{|l| puts l}
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This replaces existing calls to 'puts' in the gem with a custom logger, which can be captured during test runs and shown (along with the call stack) or hidden.

Unfortunately, there was already a logger defined for this gem, but it had non-standard interface, so I created a second logger.  Long term, I would recommend either combining these cases if possible, or renaming the existing logger to something else and renaming this to plain 'Logger'
