### PR TITLE
Add separate identifiers for random questions

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,6 @@
+2024-01-29 Version 0.2.44
+  * Have random question types have separate identifiers to the originals
+
 2024-01-17 Version 0.2.43
   * Handle 4.1 question to quiz mapping
 

--- a/lib/moodle2cc/canvas_cc/models/assessment.rb
+++ b/lib/moodle2cc/canvas_cc/models/assessment.rb
@@ -93,11 +93,10 @@ module Moodle2CC::CanvasCC::Models
         new_group = Moodle2CC::CanvasCC::Models::QuestionGroup.new
         new_group.identifier = "#{@identifier}#{bank.identifier}_random_group"
         new_group.selection_number = count
-
-        new_group.questions = bank.questions.map(&:dup)
+        new_group.questions = bank.questions.map(&:dup).map{|q| (q.identifier = "random_#{q.identifier}") && q }
         child_banks = bank.find_children_banks(question_banks)
         child_banks.each do |child|
-          new_group.questions += child.questions.map(&:dup)
+          new_group.questions += child.questions.map(&:dup).map{|q| (q.identifier = "random_#{q.identifier}") && q }
         end
 
         @items << new_group

--- a/lib/moodle2cc/version.rb
+++ b/lib/moodle2cc/version.rb
@@ -1,3 +1,3 @@
 module Moodle2CC
-  VERSION = "0.2.43"
+  VERSION = "0.2.44"
 end

--- a/spec/moodle2cc/canvas_cc/models/assessment_spec.rb
+++ b/spec/moodle2cc/canvas_cc/models/assessment_spec.rb
@@ -120,12 +120,12 @@ describe Moodle2CC::CanvasCC::Models::Assessment do
     group1 = subject.items[0]
     expect(group1.class).to eq Moodle2CC::CanvasCC::Models::QuestionGroup
     expect(group1.selection_number).to eq 2
-    expect(group1.questions.map(&:identifier)).to eq [q1, q2, q3].map(&:identifier)
+    expect(group1.questions.map(&:identifier)).to eq [q1, q2, q3].map{|q| "random_#{q.identifier}"}
 
     group2 = subject.items[1]
     expect(group2.class).to eq Moodle2CC::CanvasCC::Models::QuestionGroup
     expect(group2.selection_number).to eq 1
-    expect(group2.questions.map(&:identifier)).to eq qb3.questions.map(&:identifier)
+    expect(group2.questions.map(&:identifier)).to eq qb3.questions.map{|q| "random_#{q.identifier}"}
   end
 
 end


### PR DESCRIPTION
Having questions parsed and converted once and written to xml twice (because they were duped) caused problems since they shared identifiers without really being the same resource.